### PR TITLE
Fix disable ui

### DIFF
--- a/src/applet/connections.c
+++ b/src/applet/connections.c
@@ -369,7 +369,7 @@ restart_connection(GtkDialog *dialog, gint response_id, gpointer user_data)
         if (!g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, 0, NULL, &pid,
                            &err))
         {
-          ULOG_DEBUG(err->message);
+          ULOG_DEBUG("%s", err->message);
           g_clear_error(&err);
         }
 

--- a/src/iap/iap-conndlg.c
+++ b/src/iap/iap-conndlg.c
@@ -134,6 +134,14 @@ show_no_conn_available(struct iap_conndlg_private **iap_conndlg)
     gtk_widget_show_all((*iap_conndlg)->no_conn);
     gtk_widget_set_sensitive(GTK_WIDGET((*iap_conndlg)->scan_box_view), FALSE);
     (*iap_conndlg)->ui_disabled = TRUE;
+  } else {
+    if ((*iap_conndlg)->no_conn)
+    {
+      gtk_widget_destroy((*iap_conndlg)->no_conn);
+      (*iap_conndlg)->no_conn = NULL;
+    }
+    gtk_widget_set_sensitive(GTK_WIDGET((*iap_conndlg)->scan_box_view), TRUE);
+    (*iap_conndlg)->ui_disabled = FALSE;
   }
 
   g_list_free(l);


### PR DESCRIPTION
```
    iap-conndlg: show_no_conn_available: also hide

    This function gets called from scan_stopped() regardless, and from
    iap_conndlg_display_event_cb() when the scan start fails.

    What happens is that the UI is disabled, then a scan finishes, and
    scan_stoppped is called, which will call show_no_conn_available() to
    disable the UI in case there are no networks available. But it will
    never actually enable UI if there are networks available; this only
    happens when the next scan starts.

    Fix it by also enabling the UI in show_no_conn_available.
```