### PR TITLE
Add providers tab to advanced iap settings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+connui-internet (2.79.4) unstable; urgency=low
+
+  * advanced: Add providers tab
+
+ -- Merlijn Wajer <merlijn@wizzup.org>  Tue, 24 Aug 2021 08:00:32 +0200
+
 connui-internet (2.79.3) unstable; urgency=low
 
   * easy-wlan: When scanning for a hidden AP, flush supplicant cache first

--- a/src/settings/wizard.c
+++ b/src/settings/wizard.c
@@ -667,6 +667,11 @@ static struct iap_wizard_page iap_wizard_pages[] =
   {0}
 };
 
+/* TODO: maybe generate these automatically, at least the IDs, based on existing
+ * configs, we want only specific ids for the dummy_provider */
+static char* provider_types[] = {"", "DUMMY",  NULL};
+static char* provider_ids[] = {"", "dummy-provider",  NULL};
+
 static struct stage_widget iap_wizard_widgets[] =
 {
   {NULL, NULL, "NAME", "name", NULL, &mapper_entry2string, NULL},
@@ -686,6 +691,8 @@ static struct stage_widget iap_wizard_widgets[] =
   {NULL, NULL, "IPV4_AUTO_DNS", "ipv4_autodns", NULL, &mapper_toggle2bool, NULL},
   {NULL, NULL, "IPV4_DNS1", "ipv4_dns1", NULL, &mapper_entry2string, NULL},
   {NULL, NULL, "IPV4_DNS2", "ipv4_dns2", NULL, &mapper_entry2string, NULL},
+  {NULL, NULL, "PROVIDER_SERVICE_TYPE", "service_type", NULL, &mapper_combo2string, provider_types},
+  {NULL, NULL, "PROVIDER_SERVICE_ID", "service_id", NULL, &mapper_combo2string, provider_ids},
   {0, }
 };
 

--- a/src/settings/wizard.c
+++ b/src/settings/wizard.c
@@ -667,11 +667,6 @@ static struct iap_wizard_page iap_wizard_pages[] =
   {0}
 };
 
-/* TODO: maybe generate these automatically, at least the IDs, based on existing
- * configs, we want only specific ids for the dummy_provider */
-static char* provider_types[] = {"", "DUMMY",  NULL};
-static char* provider_ids[] = {"", "dummy-provider",  NULL};
-
 static struct stage_widget iap_wizard_widgets[] =
 {
   {NULL, NULL, "NAME", "name", NULL, &mapper_entry2string, NULL},
@@ -691,8 +686,8 @@ static struct stage_widget iap_wizard_widgets[] =
   {NULL, NULL, "IPV4_AUTO_DNS", "ipv4_autodns", NULL, &mapper_toggle2bool, NULL},
   {NULL, NULL, "IPV4_DNS1", "ipv4_dns1", NULL, &mapper_entry2string, NULL},
   {NULL, NULL, "IPV4_DNS2", "ipv4_dns2", NULL, &mapper_entry2string, NULL},
-  {NULL, NULL, "PROVIDER_SERVICE_TYPE", "service_type", NULL, &mapper_combo2string, provider_types},
-  {NULL, NULL, "PROVIDER_SERVICE_ID", "service_id", NULL, &mapper_combo2string, provider_ids},
+  {NULL, NULL, "PROVIDER_SERVICE_TYPE", "service_type", NULL, &mapper_combo2string, NULL},
+  {NULL, NULL, "PROVIDER_SERVICE_ID", "service_id", NULL, &mapper_combo2string, NULL},
   {0, }
 };
 


### PR DESCRIPTION
This adds support for selecting providers in the advanced internet settings.

I think the service_type should be a list of what we can find in gconf under `/system/osso/connectivity/srv_provider`.
The service_id I am less sure of, I think we need to figure out where we write those (they could indicate different provider configs, like different openvpn networks, or something).

Currently the values are just hardcoded and in sync with https://github.com/maemo-leste/libicd-provider-dummy/
